### PR TITLE
fix usebean name and update one wrong parameter name

### DIFF
--- a/semi2/src/main/webapp/support/faq.jsp
+++ b/semi2/src/main/webapp/support/faq.jsp
@@ -3,9 +3,9 @@
 <%@ page import="java.util.*" %>	
 <%@ page import="com.plick.support.*" %>
 <jsp:useBean id="faqDao" class="com.plick.support.FaqDao"></jsp:useBean>
-<jsp:useBean id="memberDto" class="com.plick.dto.MemberDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.signedinDto" scope="session"></jsp:useBean>
 <%
-String accessType=memberDto.getAccessType();
+String accessType=signedinDto.getMemberAccessType();
 if(accessType==null){
 	accessType="";
 }

--- a/semi2/src/main/webapp/support/faq/write.jsp
+++ b/semi2/src/main/webapp/support/faq/write.jsp
@@ -1,8 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<jsp:useBean id="memberDto" class="com.plick.dto.MemberDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.signedinDto" scope="session"></jsp:useBean>
 <%
-String accessType=memberDto.getAccessType();
+String accessType=signedinDto.getMemberAccessType();
 if(accessType==null){
 	accessType="";
 }
@@ -27,7 +27,7 @@ if(!accessType.equals("admin")){
 <form name="writeForm" action="/semi2/support/faq/write_ok.jsp" method="post">
 <label>제목</label><input name="title" type="text" placeholder="제목을 입력하세요."><br>
 <textarea name="content"></textarea>
-<input type="hidden" name="id" value="<%=memberDto.getId()%>">
+<input type="hidden" name="memberId" value="<%=signedinDto.getMemberId()%>">
 <input type="submit" value="글쓰기">
 </form>
 

--- a/semi2/src/main/webapp/support/main.jsp
+++ b/semi2/src/main/webapp/support/main.jsp
@@ -3,9 +3,9 @@
 <%@ page import="java.util.*" %>	
 <%@ page import="com.plick.support.*" %>
 <jsp:useBean id="ndao" class="com.plick.support.NoticeDao"></jsp:useBean>
-<jsp:useBean id="memberDto" class="com.plick.dto.MemberDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.signedinDto" scope="session"></jsp:useBean>
 <%
-String accessType=memberDto.getAccessType();
+String accessType=signedinDto.getMemberAccessType();
 if(accessType==null){
 	accessType="";
 }

--- a/semi2/src/main/webapp/support/notice/write.jsp
+++ b/semi2/src/main/webapp/support/notice/write.jsp
@@ -1,8 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<jsp:useBean id="memberDto" class="com.plick.dto.MemberDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.signedinDto" scope="session"></jsp:useBean>
 <%
-String accessType=memberDto.getAccessType();
+String accessType=signedinDto.getMemberAccessType();
 if(accessType==null){
 	accessType="";
 }
@@ -27,7 +27,7 @@ if(!accessType.equals("admin")){
 <form name="writeForm" action="/semi2/support/notice/write_ok.jsp" method="post">
 <label>제목</label><input name="title" type="text" placeholder="제목을 입력하세요."><br>
 <textarea name="content"></textarea>
-<input type="hidden" name="id" value="<%=memberDto.getId()%>">
+<input type="hidden" name="memberId" value="<%=signedinDto.getMemberId()%>">
 <input type="submit" value="글쓰기">
 </form>
 

--- a/semi2/src/main/webapp/support/question.jsp
+++ b/semi2/src/main/webapp/support/question.jsp
@@ -3,11 +3,11 @@
 <%@ page import="java.util.*" %>	
 <%@ page import="com.plick.support.*" %>
 <jsp:useBean id="questionDao" class="com.plick.support.QuestionDao"></jsp:useBean>
-<jsp:useBean id="memberDto" class="com.plick.dto.MemberDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.signedinDto" scope="session"></jsp:useBean>
 <%
+String accessType=signedinDto.getMemberAccessType();
 boolean sw = true;
-String accessType=memberDto.getAccessType();
-int memberId = memberDto.getId();
+int memberId = signedinDto.getMemberId();
 if(accessType==null){
 	accessType="";
 }

--- a/semi2/src/main/webapp/support/question/answer.jsp
+++ b/semi2/src/main/webapp/support/question/answer.jsp
@@ -1,10 +1,10 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
 <%request.setCharacterEncoding("UTF-8"); %>      
-<jsp:useBean id="memberDto" class="com.plick.dto.MemberDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.signedinDto" scope="session"></jsp:useBean>
 <%
+String accessType=signedinDto.getMemberAccessType();
 String title = request.getParameter("title");
-String accessType=memberDto.getAccessType();
 if(!accessType.equals("admin")){
 	%>
 	<script>
@@ -27,10 +27,11 @@ if(!accessType.equals("admin")){
 <form name="writeForm" action="/semi2/support/question/answer_ok.jsp" method="post">
 <label>제목</label><input name="title" type="text" value="re:<%=title%>"><br>
 <textarea name="content"></textarea>
-<input type="hidden" name="memberId" value="<%=memberDto.getId()%>">
+<input type="hidden" name="memberId" value="<%=signedinDto.getMemberId()%>">
 <input type="hidden" name="parentId" value="<%=request.getParameter("id") %>">
 <script>
-window.alert('<%=request.getParameter("id") %>')
+window.alert('<%=signedinDto.getMemberId() %>')
+window.alert('parentId:<%=request.getParameter("id") %>')
 </script>
 <input type="submit" value="글쓰기">
 </form>

--- a/semi2/src/main/webapp/support/question/showContent.jsp
+++ b/semi2/src/main/webapp/support/question/showContent.jsp
@@ -2,7 +2,8 @@
     pageEncoding="UTF-8"%>
 <%@ page import="com.plick.support.*" %>    
 <jsp:useBean id="questionDao" class="com.plick.support.QuestionDao"></jsp:useBean>
-<jsp:useBean id="memberDto" class="com.plick.dto.MemberDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.signedinDto" scope="session"></jsp:useBean>
+
 
 <%
 String swAnswer = request.getParameter("answer");
@@ -36,7 +37,7 @@ if(id_str==null||id_str.equals("")){
 			<td colspan="2"><%=dto.getContent() %>
 			
 			<%
-			String accessType=memberDto.getAccessType();
+			String accessType=signedinDto.getMemberAccessType();
 			if(accessType==null){
 				accessType="";
 			}
@@ -46,7 +47,7 @@ if(id_str==null||id_str.equals("")){
 				<td>
 				<form action="/semi2/support/question/answer.jsp" method="post">
 				<input type="hidden" name="title" value="<%=dto.getTitle() %>">
-				<input type="hidden" name="id" value="<%=dto.getId() %>">
+				<input type="hidden" name="id" value="<%=dto.getParentId() %>">
 				<input type="submit" value="답글">
 				
 				</form>

--- a/semi2/src/main/webapp/support/question/write.jsp
+++ b/semi2/src/main/webapp/support/question/write.jsp
@@ -1,8 +1,8 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
     pageEncoding="UTF-8"%>
-<jsp:useBean id="memberDto" class="com.plick.dto.MemberDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.signedinDto" scope="session"></jsp:useBean>
 <%
-String accessType=memberDto.getAccessType();
+String accessType=signedinDto.getMemberAccessType();
 if(accessType==null){
 	%>
 	<script>
@@ -25,7 +25,7 @@ if(accessType==null){
 <form name="writeForm" action="/semi2/support/question/write_ok.jsp" method="post">
 <label>제목</label><input name="title" type="text" placeholder="제목을 입력하세요."><br>
 <textarea name="content"></textarea>
-<input type="hidden" name="memberId" value="<%=memberDto.getId()%>">
+<input type="hidden" name="memberId" value="<%=signedinDto.getMemberId()%>">
 <input type="submit" value="글쓰기">
 </form>
 


### PR DESCRIPTION
유스빈 이름 signedindto로 수정함
signedinDao에서 쿼리문이 멤버쉽이 있는 사람 아니면 멤버아이디가 안담기게끔 결과가 나오는 듯 
그래서 1대1게시판에서 답글 달면 오류 발생함
쿼리문의 셀렉트문에 members.id member_id 를 추가하면 정상적으로 signedinDto에 담기는듯

추가로 question폴더 showContent에서 answer로 넘기는 파라미터가 id가 아니라 parentId여야 해서 수정함