### PR TITLE
fix: modify query inside signedao

### DIFF
--- a/semi2/src/main/java/com/plick/signedin/signedinDao.java
+++ b/semi2/src/main/java/com/plick/signedin/signedinDao.java
@@ -24,8 +24,8 @@ public class signedinDao {
 	public int verifySignin(signedinDto dto) {
 		try {
 			conn = com.plick.db.DBConnector.getConn();
-			String sql = "SELECT name, nickname, tel, email, password, access_type, created_at, "
-					+ "description, membership_members.id, membership_id, member_id, started_at, stopped_at "
+			String sql = "SELECT members.id AS member_id, name, nickname, tel, email, password, access_type, created_at, "
+					+ "description, membership_members.id AS membership_member_id, membership_id, started_at, stopped_at "
 					+ "FROM members LEFT OUTER JOIN membership_members "
 					+ "ON members.id = membership_members.member_id " + "WHERE members.email = ?";
 			pstmt = conn.prepareStatement(sql);
@@ -35,6 +35,7 @@ public class signedinDao {
 			if (rs.next()) {
 				if (!rs.getString("password").equals(dto.getMemberPassword()))
 					return INVALID_PWD;
+				dto.setMemberId(rs.getInt("member_id"));
 				dto.setMemberName(rs.getString("name"));
 				dto.setMemberNickname(rs.getString("nickname"));
 				dto.setMemberTel(rs.getString("tel"));
@@ -42,9 +43,8 @@ public class signedinDao {
 				dto.setMemberAccessType(rs.getString("access_type"));
 				dto.setMemberCreatedAt(rs.getTimestamp("created_at"));
 				dto.setMemberDescription(rs.getString("description"));
-				dto.setId(rs.getInt("id"));
+				dto.setMembershipMemberId(rs.getInt("membership_member_id"));
 				dto.setMembershipId(rs.getInt("membership_id"));
-				dto.setMemberId(rs.getInt("member_id"));
 				dto.setMembershipStarted_at(rs.getTimestamp("started_at"));
 				dto.setMembershipStopped_at(rs.getTimestamp("stopped_at"));
 				return SIGNIN_SUCCESS;

--- a/semi2/src/main/java/com/plick/signedin/signedinDto.java
+++ b/semi2/src/main/java/com/plick/signedin/signedinDto.java
@@ -3,7 +3,7 @@ package com.plick.signedin;
 import java.sql.Timestamp;
 
 public class signedinDto {
-	private int id;
+	private int membershipMemberId;
 	private int memberId;
 	private int membershipId;
 	private String memberName;
@@ -27,7 +27,7 @@ public class signedinDto {
 			Timestamp memberCreatedAt, String memberDescription, Timestamp membershipStarted_at,
 			Timestamp membershipStopped_at) {
 		super();
-		this.id = id;
+		this.membershipMemberId = id;
 		this.memberId = memberId;
 		this.membershipId = membershipId;
 		this.memberName = memberName;
@@ -44,12 +44,12 @@ public class signedinDto {
 
 
 
-	public int getId() {
-		return id;
+	public int getMembershipMemberId() {
+		return membershipMemberId;
 	}
 
-	public void setId(int id) {
-		this.id = id;
+	public void setMembershipMemberId(int id) {
+		this.membershipMemberId = id;
 	}
 
 	public int getMemberId() {


### PR DESCRIPTION
기존의 meberships 테이블에서 참조해오던 member_id를 members 테이블의 id 값으로 변경해서
맴버쉽을 보유하지 않은 유저여도 meber_id 컬럼 값을 dto에 저장하도록 변경했습니다 