### PR TITLE
fix: fix incorrect song count display on mylist/main page

### DIFF
--- a/semi2/src/main/java/com/plick/playlist/main/PlaylistMainDao.java
+++ b/semi2/src/main/java/com/plick/playlist/main/PlaylistMainDao.java
@@ -64,7 +64,7 @@ public class PlaylistMainDao {
 	private List<PlaylistPreviewDto> findPlaylistsPopularByLimit(int limit, Connection conn) {
 		String sql = "SELECT *  " + "FROM ( " + "    SELECT   " + "        p.id AS playlist_id, "
 				+ "        m.id AS member_id, " + "        p.name AS playlist_name, "
-				+ "        p.created_at AS created_at, " + "        COUNT(DISTINCT ps.song_id) AS song_count, "
+				+ "        p.created_at AS created_at, " + "        COUNT(DISTINCT ps.id) AS song_count, "
 				+ "        COUNT(DISTINCT l.member_id) AS like_count, " + "        m.nickname AS member_nickname, "
 				+ "        s.album_id AS first_album_id " + "    FROM playlists p "
 				+ "    LEFT JOIN playlist_songs ps ON p.id = ps.playlist_id "


### PR DESCRIPTION
1. 플레이리스트/마이리스트/메인 페이지에서 플리의 몇 곡 을 잘못 표시하는 문제 수정
이유 : dao에서 쿼리문에 song count를 song_id로 중복 제거해서 카운팅하고 있었음. 기본키인 id로 교체해서 중복도 카운팅되게 변경