### PR TITLE
Fix/chart/main search incorrect result

### DIFF
--- a/semi2/src/main/java/com/plick/chart/ChartDao.java
+++ b/semi2/src/main/java/com/plick/chart/ChartDao.java
@@ -222,11 +222,11 @@ public class ChartDao {
 	public ArrayList<TrackDto> genreChartList(String genre) {
 		try {
 			conn = com.plick.db.DBConnector.getConn();
-			String sql = "SELECT rownum AS rnum,a.* "
-					+ "FROM (SELECT s.*, m.NICKNAME AS \"artist\", a.NAME AS \"album_name\",a.MEMBER_ID "
-					+ "FROM MEMBERS m, ALBUMS a, SONGS s "
-					+ "WHERE m.ID = a.MEMBER_ID AND a.ID = s.ALBUM_ID AND rownum<=30 AND (a.GENRE1 = ? OR a.GENRE2 = ? OR a.GENRE3 = ?) "
-					+ "ORDER BY s.VIEW_COUNT desc)a " + "ORDER BY RNUM";
+			String sql = "SELECT rownum as rnum , a.* " + "FROM ( "
+					+ "    SELECT s.*, m.NICKNAME AS artist, a.NAME AS album_name, a.MEMBER_ID "
+					+ "    FROM MEMBERS m, ALBUMS a, SONGS s " + "    WHERE m.ID = a.MEMBER_ID "
+					+ "      AND a.ID = s.ALBUM_ID " + "      AND (a.GENRE1 = ? OR a.GENRE2 = ? OR a.GENRE3 = ?) "
+					+ "    ORDER BY s.VIEW_COUNT DESC" + ") a " + "WHERE rownum <= 30 ";
 
 			ps = conn.prepareStatement(sql);
 			ps.setString(1, genre);
@@ -509,7 +509,7 @@ public class ChartDao {
 			}
 		}
 	}
-	
+
 	// 앨범 평점 수정
 	public int updateRating(int memberId, int albumId, int score) {
 		try {

--- a/semi2/src/main/webapp/chart/song-details.jsp
+++ b/semi2/src/main/webapp/chart/song-details.jsp
@@ -69,11 +69,11 @@ SongDetailDto dto = sdao.findSong(id);
 				</tr>
 				<tr>
 					<th>작곡</th>
-					<td><%=dto.getComposer() %></td>
+					<td><%=dto.getComposer()==null?"":dto.getComposer() %></td>
 				</tr>
 				<tr>
 					<th>작사</th>
-					<td><%=dto.getLyricist() %></td>
+					<td><%=dto.getLyricist()==null?"":dto.getLyricist() %></td>
 				</tr>
 				<tr class="lyrics">
 					<td colspan="2"><br><%=dto.getLyrics().replaceAll("\n", "<br>")%></td>


### PR DESCRIPTION
1. 장르별 차트가 정상적인 순위로 표시되게 수정
* 원인 : DAO 쿼리에서 전체검색-30개 자르기-조회수로 정렬 순서로 진행되고 있었음.
* 해결 : 전체검색-조회수로 정렬-30개 자르기 순서로 쿼리 수정함.

2. 송 디테일 페이지에서 작곡과 작사에 "null" 문자열이 표시되는 문제 수정
* 원인 : 샘플데이터에 작곡, 작사가가 없을 때 빈 문자열을 집어넣는데, 오라클에서는 빈 문자열도 null로 인식, DAO로 불러오면 null 객체로 매핑됨. 
* 해결 : null이면 빈 문자열을 표시하도록 수정