### PR TITLE
fix: fix index out of bounds exception when this page has playlists

### DIFF
--- a/semi2/src/main/webapp/main.jsp
+++ b/semi2/src/main/webapp/main.jsp
@@ -2,7 +2,7 @@
 <%@ page import="com.plick.root.*"%>
 <%@ page import="java.util.*"%>
 <jsp:useBean id="rdao" class="com.plick.root.RootDao"></jsp:useBean>
-
+<%! static final int MAX_PLAYLISTS_LENGTH = 5;  %>
 <!DOCTYPE html>
 <html>
 <head>
@@ -188,7 +188,7 @@
 				<%
 			}else{
 				
-				for (int i=0;i<5;i++){
+				for (int i=0;i<Math.min(MAX_PLAYLISTS_LENGTH, arrPopularPlaylist.size());i++){
 					%>
 				<div class="gallery-card">
 					<div class="gallery-card-album-image-group">


### PR DESCRIPTION
1. 루트 메인 페이지에서 플레이리스트가 5개 미만일 때 index out of bounds 예외 발생하는 문제 해결
* 원인: 반복문이 다섯 번 반복하는데, 받아온 플레이리스트가 5개가 안되면 예외 발생
* 해결: 5개와 플레이리스트 길이중 작은 수만큼 반복하게 수정