### PR TITLE
Fix/modify signedin data usebean to attribute

### DIFF
--- a/semi2/src/main/webapp/css/main.css
+++ b/semi2/src/main/webapp/css/main.css
@@ -110,7 +110,7 @@ header {
 .login-profile-image {
 	width: 40px;
 	object-fit: cover;
-	border-radius: 50%;
+	clip-path: circle(50% at center);
 }
 
 /*공통요소*/
@@ -1403,9 +1403,9 @@ table.support-table .support-table-foot {
 }
 
 .mypage-artist-image {
-	width: 140px;
+	width: 154px;
 	margin-bottom: 5px;
-	border-radius: 999px;
+	clip-path: circle(45% at center);
 	transition: filter 0.3s ease;
 	display: block;
 	margin: 20px auto;

--- a/semi2/src/main/webapp/member/signin_ok.jsp
+++ b/semi2/src/main/webapp/member/signin_ok.jsp
@@ -3,7 +3,7 @@
 <%
 request.setCharacterEncoding("UTF-8");
 %>
-<jsp:useBean id="signedinDto" class="com.plick.signedin.SignedinDto" scope="session"></jsp:useBean>
+<jsp:useBean id="signedinDto" class="com.plick.signedin.SignedinDto"></jsp:useBean>
 <jsp:setProperty property="*" name="signedinDto"/>	
 <jsp:useBean id="signedinDao" class="com.plick.signedin.SignedinDao"></jsp:useBean>
 <%
@@ -13,6 +13,7 @@ String path = "";
 
 switch(result){
 case 0: 
+	//로그인 정보 쿠키 추가
 if(request.getParameter("rememberMe")!=null){
 	Cookie rememberMe = new Cookie("rememberMe", signedinDto.getMemberEmail());
 	rememberMe.setMaxAge(signedinDao.COOKIE_LIFE_30DAYS);
@@ -26,6 +27,8 @@ if(request.getParameter("rememberMe")!=null){
 		}
 	}
 }
+
+session.setAttribute("signedinDto", signedinDto);
 msg = "로그인 성공!";
 path = "/semi2/main.jsp";
 break;

--- a/semi2/src/main/webapp/mypage/edit-profile-img.jsp
+++ b/semi2/src/main/webapp/mypage/edit-profile-img.jsp
@@ -117,7 +117,7 @@ function reloadCtxE(w, h, div){
 	
 	const centerX = width / 2;
 	const centerY = height / 2;
-	const radius = Math.min(width, height) / 2.5;
+	const radius = Math.min(width, height) / 2.2;
 	
 	//1. 전체 회색 배경
 	ctxE.fillStyle = "#808080";

--- a/semi2/src/main/webapp/player/version-min.jsp
+++ b/semi2/src/main/webapp/player/version-min.jsp
@@ -9,11 +9,6 @@
 <title>Insert title here</title>
 </head>
 <body>
-<%
-// 세션에서 로컬 플리 정보를 받아와서 매핑해야 함
-MemberDao memberDao = new MemberDao();
-memberDao.addMember10000();
-%>
 <label>앨범 커버</label>
 <label>곡 명</label>
 <label>아티스트</label>


### PR DESCRIPTION
1. 로그인 완료시 세션에 데이터가 추가되는 시점을 검증 후로 변경했습니다
2. usebean의 호출은 제어할 수 없이 무조건 발생하기 때문에 signedinDto를 세션에 직접 세팅했습니다
3. 프로필 이미지, 마이페이지 이미지, 에디터캔버스의 원형 이미지 노출 비율을 1대1로 동기화 했습니다
** 이미지의 크기는 그대로 보이도록 동기화 과정에서 줄어든 이미지의 비율만큼 width를 증가시켰습니다
- 마이페이지 이미지 노출 영역 10퍼센트 감소 width 10퍼센트 증가