### PR TITLE
test: add TimeFilter class for execution time log each page

### DIFF
--- a/semi2/src/main/java/com/plick/test/ExecutionTimeFilter.java
+++ b/semi2/src/main/java/com/plick/test/ExecutionTimeFilter.java
@@ -1,0 +1,37 @@
+package com.plick.test;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.annotation.WebFilter;
+import javax.servlet.http.HttpServletRequest;
+
+@WebFilter("/*") // 전체 요청에 적용
+public class ExecutionTimeFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+
+		String uri = ((HttpServletRequest) request).getRequestURI();
+		if (uri.startsWith("/semi2/resources/") || uri.endsWith(".css") || uri.endsWith(".js")) {
+			chain.doFilter(request, response);
+			return;
+		}
+		long start = System.currentTimeMillis();
+
+		chain.doFilter(request, response);
+
+		long end = System.currentTimeMillis();
+		long duration = end - start;
+
+		String queryString = ((HttpServletRequest) request).getQueryString();
+		System.out.println("[" + ((HttpServletRequest) request).getRequestURI()
+				+ ((queryString == null) ? "" : "?" + java.net.URLDecoder.decode(queryString, "UTF-8")) + "] 처리 시간: "
+				+ duration + "ms");
+	}
+}


### PR DESCRIPTION
1. 각 페이지 처리시간을 콘솔에 로그로 남기는 코드 추가.
* 각 페이지 최초 요청시 리소스파일 다운로드, 서블릿 컴파일로 인해 오래 걸릴 수 있음.