### PR TITLE
Fix/fix mypage profile

### DIFF
--- a/semi2/src/main/java/com/plick/member/MemberDao.java
+++ b/semi2/src/main/java/com/plick/member/MemberDao.java
@@ -31,6 +31,7 @@ public class MemberDao {
 			pstmt.setString(6, dto.getAccessType());
 			int result = pstmt.executeUpdate();
 			return result;
+			
 		}catch(Exception e) {
 			e.printStackTrace();
 			return ERROR;

--- a/semi2/src/main/webapp/member/signin.jsp
+++ b/semi2/src/main/webapp/member/signin.jsp
@@ -54,7 +54,7 @@ function goSubmit(button){
 </div>
 <div class="login-sub-box">
 	<div class="login-find">
-		<label onclick="location.href = '/semi2/member/find/id.jsp<%=rtm = rtm != null ? "?returntome="+rtm : null%>;'">아이디 찾기</label>
+		<label onclick="location.href = '/semi2/member/find/id.jsp<%=rtm != null ? "?returntome="+rtm : ""%>;'">아이디 찾기</label>
 		</div>
 		 <div class="login-find-line"> | </div>
 			<div class="login-find">

--- a/semi2/src/main/webapp/member/signin.jsp
+++ b/semi2/src/main/webapp/member/signin.jsp
@@ -21,22 +21,30 @@ for(int i = 0; i < cookies.length; i++){
 %>
 <script>
 function goSubmit(button){
-	
-	var form = button.closest("form");
-	form.action = "signin_ok.jsp?ref="+document.referrer;
-	form.submit();
+	var a = true;
+	if (document.getElementById("memberEmail").value == null || document.getElementById("memberEmail").value.trim() == ""){
+		a = false;
+	}
+	if (document.getElementById("memberPassword").value == null || document.getElementById("memberPassword").value.trim() == ""){
+		if (a) a = false;
+	}
+	if (a){
+		var form = button.closest("form");
+		form.action = "signin_ok.jsp";
+		form.submit();
+	}else window.alert("아이디와 비밀번호를 모두 입력해주세요.");
 }
 </script>
 </head>
 <link rel="stylesheet" type="text/css" href="/semi2/css/main.css">
-<body onload = "checkRememberMe();">
+<body>
 <%@ include file="/header.jsp" %>
 <div class="login-box">
 <div class="login-input">
 	<form method = "post">
-		<input type="email" name = "memberEmail" class="login-text" placeholder="아이디(이메일)" <%=rememberEmail!=null?"value='"+rememberEmail+"'":"" %>>
+		<input type="email" name = "memberEmail" id = "memberEmail" class="login-text" placeholder="아이디(이메일)" <%=rememberEmail!=null?"value='"+rememberEmail+"'":"" %>>
 		<br>
-		<input type="password" name = "memberPassword" class="login-text" placeholder="비밀번호">
+		<input type="password" name = "memberPassword" id = "memberPassword" class="login-text" placeholder="비밀번호">
 		<br>
 		<div class="id-checkbox">
 		<input type="checkbox" id="remeberMe" name="rememberMe" <%=rememberEmail!=null?"checked":"" %>><div class="id-remember">아이디 저장</div>

--- a/semi2/src/main/webapp/member/signup/form_ok.jsp
+++ b/semi2/src/main/webapp/member/signup/form_ok.jsp
@@ -5,7 +5,6 @@
 <%@ page import="java.io.File" %>
 <%@ page import="com.plick.member.MemberDto" %>
 <%
-//
 request.setCharacterEncoding("UTF-8");
 %>
 
@@ -14,16 +13,21 @@ request.setCharacterEncoding("UTF-8");
 <jsp:useBean id="memberDao" class = "com.plick.member.MemberDao"></jsp:useBean>
 
 <%
-memberDto.setAccessType("listener");
+//컨트롤러 페이지에서 2차 검증 시도
+String msg = "동시 접속자 수가 너무 많습니다. 다시 시도해주세요.";
+if (memberDao.checkEmailDuplicate(request.getParameter("email")) < 0 || memberDao.checkEmailDuplicate(request.getParameter("nickname")) < 0){
+}else{
 
-int result = memberDao.addMember(memberDto);
-String msg = result > 0 ? "회원가입 성공" : "오류 발생!";
-
-int memberId = memberDao.searchId(memberDto.getEmail());
-System.out.println(memberId+"memberId");
-File profile = new File(request.getRealPath("resources/images/member/"+memberId));
-profile.mkdirs();
-System.out.println(profile.exists()+"!memberId");
+	memberDto.setAccessType("listener");
+	
+	int result = memberDao.addMember(memberDto);
+	msg = result > 0 ? "회원가입 성공" : "오류 발생!";
+	
+	int memberId = memberDao.searchId(memberDto.getEmail());
+	System.out.println(memberId+"memberId");
+	File profile = new File(request.getRealPath("resources/images/member/"+memberId));
+	profile.mkdirs();
+}
 %>
 
 <script>

--- a/semi2/src/main/webapp/mypage/description_hidden.jsp
+++ b/semi2/src/main/webapp/mypage/description_hidden.jsp
@@ -14,5 +14,12 @@
 	parent.window.alert("<%=rs%>개의 업데이트 완료");
 	</script>
 	<%
+	}else{
+		%>
+		<script>
+		window.alert("잘못된 접근입니다. 메인페이지로 돌아갑니다.");
+		location.href = "/semi2/main.jsp";
+		</script>
+		<%
 	}
 	%>

--- a/semi2/src/main/webapp/mypage/profile.jsp
+++ b/semi2/src/main/webapp/mypage/profile.jsp
@@ -54,9 +54,7 @@ textarea::-webkit-scrollbar {
 				id="duplicateNickname"></label> <input type="hidden"
 				id="nicknamecheck" value="true">
 		</div>
-		<textarea name = "description" id = "description" rows = "10" cols = "70" maxlength = "4000" readonly class="login-text">
-		<%=signedinDto.getMemberDescription() == null ? "" : signedinDto.getMemberDescription() %>
-		</textarea>
+		<textarea name = "description" id = "description" rows = "10" cols = "70" maxlength = "4000" readonly class="login-text"><%=signedinDto.getMemberDescription() == null ? "" : signedinDto.getMemberDescription() %></textarea>
 		<input type = "button" value = "프로필 메세지 수정" id = "descriptionBt" class="bt" onclick = "changeDescription(this);">
 	</div>
 	<%@ include file="/footer.jsp"%>
@@ -74,12 +72,13 @@ textarea::-webkit-scrollbar {
 		
 		
 		function changeDescription(bt) {
+			window.alert(document.getElementById("description").value);
 			if (bt.value == "프로필 메세지 수정"){
 				description.removeAttribute("readonly");
 				bt.value = "수정 완료";
 			}else{
 				description.setAttribute("readonly", true);
-				profileHidden.src = "description_hidden.jsp?description="+description.value;
+				profileHidden.src = "description_hidden.jsp?description="+description.value+"&memberId=<%=signedinDto.getMemberId()%>";
 				bt.value = "프로필 메세지 수정";
 				}
 			}
@@ -114,10 +113,7 @@ textarea::-webkit-scrollbar {
 		}
 		// 프로필 사진 삭제
 		function delProfileImg() {
-			document.getElementById('profile_hidden').src = "del-profile-img.jsp?memberId="
-					+
-	<%=signedinDto.getMemberId()%>
-		;
+			document.getElementById('profile_hidden').src = "del-profile-img.jsp?memberId="+"<%=signedinDto.getMemberId()%>";
 		}
 	</script>
 </body>

--- a/semi2/src/main/webapp/mypage/profile_hidden.jsp
+++ b/semi2/src/main/webapp/mypage/profile_hidden.jsp
@@ -7,6 +7,7 @@
 MypageDao mypageDao = new MypageDao();
 String nickname = request.getParameter("editNickname");
 String memberId = request.getParameter("memberId");
+String description = request.getParameter("description");
 // "editNickname"로 요청이 들어오면 닉네임 중복 검사
 if (nickname!=null && memberId==null){
 	int result = mypageDao.checkNicknameDuplicate(nickname);
@@ -29,7 +30,7 @@ if (nickname!=null && memberId==null){
 		break;
 	default:
 	}
-}else if(nickname!=null && memberId!=null){// "memberId"로 요청이 들어오면 닉네임 업데이트
+}else if(description!=null && memberId!=null){// "description"로 요청이 들어오면 닉네임 업데이트
 	int result = mypageDao.updateMemberNickname(nickname, Integer.parseInt(request.getParameter("memberId")));
 	if(result > 0){
 		signedinDto.setMemberNickname(nickname);
@@ -47,3 +48,7 @@ if (nickname!=null && memberId==null){
 	}
 }
 %>
+<script>
+widnow.alert("잘못된 접근입니다. 메인 페이지로 돌아갑니다");
+location.href = "/semi2/main.jsp";
+</script>


### PR DESCRIPTION
1. 마이페이지에서 description textarea에 공백이 포함 되던 문제
 - 원인:  HTML에서 textarea 태그의 innerText에 개행이 존재했고 textarea가 개행을 탭 두 개로 표시하고 있었음 
 - 해결:  HTML에서 개행을 삭제
 2. 아이디 찾기 페이지로 진입이 불가능하던 문제
 - 원인: 쿼리 스트링으로 null을 요청하고 있었음
 - 해결: 해당 부분 삭제
 3. 로그인 페이지에서 공백이나 빈 값으로 로그인 시도가 가능하던 문제 
 - 원인: null이나 공백에 대한 검사 코드가 없었음
 - 해결: null과 공백, white space에 대한 검사 로직 추가 