### PR TITLE
fix: change-email-data-handling-on-session

### DIFF
--- a/semi2/src/main/webapp/mypage/password-reset.jsp
+++ b/semi2/src/main/webapp/mypage/password-reset.jsp
@@ -59,7 +59,10 @@ function formCheck(event) {
 		event.preventDefault();
 		a = false;
 	}
-	if (!a) window.alert("form에 잘못된 부분 있음 확인바람");
+	if (!a){
+		window.alert("form에 잘못된 부분 있음 확인바람");
+		event.preventDefault();
+	}
 }
 </script>
 	<%@ include file="/mypage/mypage-header.jsp"%>
@@ -67,7 +70,7 @@ function formCheck(event) {
 		<div class="subtitle">
 			<h2>비밀번호 찾기</h2>
 		</div>
-	<form action = "password-reset_ok.jsp?email=<%=signedinDto.getMemberEmail() %>" method = "post" onsubmit = "formCheck(event)">
+	<form action = "password-reset_ok.jsp" method = "post" onsubmit = "formCheck(event)">
 		<input type="password" id = "pwd" name = "password" placeholder="새 비밀번호" onchange = "testPassword()" class="login-text">
 		<br>
 		<input type="password" id = "pwdTest" placeholder="새 비밀번호 확인" onchange = "testPassword()" class="login-text">

--- a/semi2/src/main/webapp/mypage/password-reset_ok.jsp
+++ b/semi2/src/main/webapp/mypage/password-reset_ok.jsp
@@ -1,10 +1,12 @@
+<%@page import="com.plick.signedin.SignedinDto"%>
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 	pageEncoding="UTF-8"%>
 <%@ page import="com.plick.member.MemberDao"%>
 <%
 request.setCharacterEncoding("UTF-8");
+SignedinDto signedinDto = (SignedinDto) session.getAttribute("signedinDto");
 MemberDao memberDao = new MemberDao();
-int result = memberDao.resetPassword(request.getParameter("password"), request.getParameter("email"));
+int result = memberDao.resetPassword(request.getParameter("password"), signedinDto.getMemberEmail());
 if (result > 0){
 %>
 <script>


### PR DESCRIPTION
1. 주소창에서 쿼리스트링으로 사용자 이메일을 직접 입력시 다른 사용자의 민감한 정보를 수정할 수 있었던 부분 수정
- 원인 : 이메일 정보를 request로 처리해서 클라이언트에서 임의로 조작할 수 있음
- 해결 : 세션의 signedinDto에 있는 이메일을 기반으로 비밀번호를 세팅하게 변경