### PR TITLE
Fix/add like count table and search-playlist

### DIFF
--- a/semi2/src/main/java/com/plick/artist/ArtistDao.java
+++ b/semi2/src/main/java/com/plick/artist/ArtistDao.java
@@ -97,17 +97,18 @@ public class ArtistDao {
 	}
 
 	private List<PlaylistPreviewDto> findPlaylistPreviewsOrderByCreatedAtByMemberId(int memberId, Connection conn) {
-		String sql = "SELECT   " + "        p.id AS playlist_id, " + "        m.id AS member_id, "
-				+ "        p.name AS playlist_name, " + "        p.created_at AS created_at, "
-				+ "        COUNT(DISTINCT l.member_id) AS like_count, "
-				+ "        COUNT(DISTINCT ps.song_id) AS song_count, " + "        m.nickname AS member_nickname, "
-				+ "        ( " + "            SELECT s.album_id " + "            FROM playlist_songs ps2 "
-				+ "            JOIN songs s ON ps2.song_id = s.id " + "            WHERE ps2.playlist_id = p.id "
-				+ "              AND ps2.turn = 1 " + "        ) AS first_album_id " + "    FROM playlists p  "
-				+ "    LEFT JOIN playlist_songs ps ON p.id = ps.playlist_id "
-				+ "    LEFT JOIN likes l ON p.id = l.playlist_id " + "    LEFT JOIN members m ON p.member_id = m.id "
-				+ "    WHERE m.id = ? " + "    GROUP BY p.id, p.name, p.created_at, m.id, m.nickname "
-				+ "    ORDER BY p.created_at DESC";
+		String sql = "SELECT    " + "        p.id AS playlist_id,  " + "        m.id AS member_id,  "
+				+ "        p.name AS playlist_name,  " + "        p.created_at AS created_at,  "
+				+ "        NVL(plc.like_count, 0) AS like_count,  "
+				+ "        COUNT(DISTINCT ps.song_id) AS song_count,  " + "        m.nickname AS member_nickname,  "
+				+ "        (  " + "            SELECT s.album_id  " + "            FROM playlist_songs ps2  "
+				+ "            JOIN songs s ON ps2.song_id = s.id  " + "            WHERE ps2.playlist_id = p.id  "
+				+ "              AND ps2.turn = 1  " + "        ) AS first_album_id  " + "FROM playlists p   "
+				+ "LEFT JOIN playlist_songs ps ON p.id = ps.playlist_id  "
+				+ "LEFT JOIN playlist_like_count plc ON p.id = plc.playlist_id  "
+				+ "LEFT JOIN members m ON p.member_id = m.id  " + "WHERE m.id = ?  "
+				+ "GROUP BY p.id, p.name, p.created_at, m.id, m.nickname, plc.like_count  "
+				+ "ORDER BY p.created_at DESC " + "";
 
 		List<PlaylistPreviewDto> playlistPreviewDtos = new ArrayList<PlaylistPreviewDto>();
 		try (PreparedStatement pstmt = conn.prepareStatement(sql);) {

--- a/semi2/src/main/java/com/plick/playlist/main/PlaylistMainDao.java
+++ b/semi2/src/main/java/com/plick/playlist/main/PlaylistMainDao.java
@@ -35,14 +35,12 @@ public class PlaylistMainDao {
 		String sql = "SELECT * " + "FROM ( " + "    SELECT  " + "        p.id AS playlist_id, "
 				+ "        m.id AS member_id, " + "        p.name AS playlist_name, "
 				+ "        p.created_at AS created_at, " + "        NVL(song_counts.song_count, 0) AS song_count, "
-				+ "        NVL(like_counts.like_count, 0) AS like_count, " + "        m.nickname AS member_nickname, "
-				+ "        s.album_id AS first_album_id " + "    FROM playlists p "
+				+ "        m.nickname AS member_nickname, " + "        s.album_id AS first_album_id "
+				+ "    FROM playlists p "
 				+ "    LEFT JOIN members m ON p.member_id = m.id " + "    LEFT JOIN ( "
 				+ "        SELECT playlist_id, COUNT(DISTINCT song_id) AS song_count " + "        FROM playlist_songs "
 				+ "        GROUP BY playlist_id " + "    ) song_counts ON p.id = song_counts.playlist_id "
-				+ "    LEFT JOIN ( " + "        SELECT playlist_id, COUNT(DISTINCT member_id) AS like_count "
-				+ "        FROM likes " + "        GROUP BY playlist_id "
-				+ "    ) like_counts ON p.id = like_counts.playlist_id " + "    LEFT JOIN ( "
+				+ "    LEFT JOIN ( "
 				+ "        SELECT playlist_id, song_id " + "        FROM playlist_songs " + "        WHERE turn = 1 "
 				+ "    ) ps2 ON p.id = ps2.playlist_id " + "    LEFT JOIN songs s ON ps2.song_id = s.id "
 				+ "    ORDER BY p.created_at DESC " + ") " + "WHERE ROWNUM <= ?";
@@ -54,7 +52,7 @@ public class PlaylistMainDao {
 			try (ResultSet rs = pstmt.executeQuery();) {
 				while (rs.next()) {
 					playlistPreviewDtos.add(new PlaylistPreviewDto(rs.getInt("playlist_id"), rs.getInt("member_id"),
-							rs.getString("playlist_name"), rs.getTimestamp("created_at"), rs.getInt("like_count"),
+							rs.getString("playlist_name"), rs.getTimestamp("created_at"), -1,
 							rs.getInt("song_count"), rs.getString("member_nickname"), rs.getInt("first_album_id")));
 				}
 			}
@@ -65,18 +63,21 @@ public class PlaylistMainDao {
 	}
 
 	private List<PlaylistPreviewDto> findPlaylistsPopularByLimit(int limit, Connection conn) {
-		String sql = "SELECT *   " + "FROM ( " + "    SELECT    " + "        p.id AS playlist_id,  "
-				+ "        m.id AS member_id,  " + "        p.name AS playlist_name,  "
-				+ "        p.created_at AS created_at,  " + "        sc.song_count, " + "        lc.like_count, "
-				+ "        m.nickname AS member_nickname,  " + "        s.album_id AS first_album_id  "
-				+ "    FROM playlists p  " + "    LEFT JOIN members m ON p.member_id = m.id " + "    LEFT JOIN ( "
-				+ "        SELECT playlist_id, COUNT(*) AS song_count  " + "        FROM playlist_songs  "
-				+ "        GROUP BY playlist_id " + "    ) sc ON p.id = sc.playlist_id " + "    LEFT JOIN ( "
-				+ "        SELECT playlist_id, COUNT(DISTINCT member_id) AS like_count  " + "        FROM likes  "
-				+ "        GROUP BY playlist_id " + "    ) lc ON p.id = lc.playlist_id " + "    LEFT JOIN ( "
-				+ "        SELECT playlist_id, song_id  " + "        FROM playlist_songs  " + "        WHERE turn = 1 "
-				+ "    ) ps2 ON p.id = ps2.playlist_id " + "    LEFT JOIN songs s ON ps2.song_id = s.id "
-				+ "    ORDER BY lc.like_count DESC NULLS LAST " + ")  " + "WHERE ROWNUM <= ? ";
+		String sql = "SELECT * " + "FROM ( " + "    SELECT inner_.*, ROWNUM rn " + "    FROM ( " + "        SELECT "
+				+ "            p.id AS playlist_id, " + "            m.id AS member_id, "
+				+ "            p.name AS playlist_name, " + "            p.created_at AS created_at, "
+				+ "            sc.song_count, " + "            lc.like_count, "
+				+ "            m.nickname AS member_nickname, " + "            s.album_id AS first_album_id "
+				+ "        FROM playlists p " + "        LEFT JOIN members m ON p.member_id = m.id "
+				+ "        LEFT JOIN ( " + "            SELECT playlist_id, COUNT(*) AS song_count "
+				+ "            FROM playlist_songs " + "            GROUP BY playlist_id "
+				+ "        ) sc ON p.id = sc.playlist_id " + "        LEFT JOIN ( "
+				+ "            SELECT playlist_id, COUNT(DISTINCT member_id) AS like_count " + "            FROM likes "
+				+ "            GROUP BY playlist_id " + "        ) lc ON p.id = lc.playlist_id "
+				+ "        LEFT JOIN ( " + "            SELECT playlist_id, song_id "
+				+ "            FROM playlist_songs " + "            WHERE turn = 1 "
+				+ "        ) ps2 ON p.id = ps2.playlist_id " + "        LEFT JOIN songs s ON ps2.song_id = s.id "
+				+ "        ORDER BY lc.like_count DESC NULLS LAST " + "    ) inner_ " + "    WHERE ROWNUM <= ? " + ")";
 
 		List<PlaylistPreviewDto> playlistPreviewDtos = new ArrayList<PlaylistPreviewDto>();
 

--- a/semi2/src/main/java/com/plick/playlist/main/PlaylistMainDao.java
+++ b/semi2/src/main/java/com/plick/playlist/main/PlaylistMainDao.java
@@ -36,14 +36,13 @@ public class PlaylistMainDao {
 				+ "        m.id AS member_id, " + "        p.name AS playlist_name, "
 				+ "        p.created_at AS created_at, " + "        NVL(song_counts.song_count, 0) AS song_count, "
 				+ "        m.nickname AS member_nickname, " + "        s.album_id AS first_album_id "
-				+ "    FROM playlists p "
-				+ "    LEFT JOIN members m ON p.member_id = m.id " + "    LEFT JOIN ( "
+				+ "    FROM playlists p " + "    LEFT JOIN members m ON p.member_id = m.id " + "    LEFT JOIN ( "
 				+ "        SELECT playlist_id, COUNT(DISTINCT song_id) AS song_count " + "        FROM playlist_songs "
 				+ "        GROUP BY playlist_id " + "    ) song_counts ON p.id = song_counts.playlist_id "
-				+ "    LEFT JOIN ( "
-				+ "        SELECT playlist_id, song_id " + "        FROM playlist_songs " + "        WHERE turn = 1 "
-				+ "    ) ps2 ON p.id = ps2.playlist_id " + "    LEFT JOIN songs s ON ps2.song_id = s.id "
-				+ "    ORDER BY p.created_at DESC " + ") " + "WHERE ROWNUM <= ?";
+				+ "    LEFT JOIN ( " + "        SELECT playlist_id, song_id " + "        FROM playlist_songs "
+				+ "        WHERE turn = 1 " + "    ) ps2 ON p.id = ps2.playlist_id "
+				+ "    LEFT JOIN songs s ON ps2.song_id = s.id " + "    ORDER BY p.created_at DESC " + ") "
+				+ "WHERE ROWNUM <= ?";
 
 		List<PlaylistPreviewDto> playlistPreviewDtos = new ArrayList<PlaylistPreviewDto>();
 
@@ -52,8 +51,8 @@ public class PlaylistMainDao {
 			try (ResultSet rs = pstmt.executeQuery();) {
 				while (rs.next()) {
 					playlistPreviewDtos.add(new PlaylistPreviewDto(rs.getInt("playlist_id"), rs.getInt("member_id"),
-							rs.getString("playlist_name"), rs.getTimestamp("created_at"), -1,
-							rs.getInt("song_count"), rs.getString("member_nickname"), rs.getInt("first_album_id")));
+							rs.getString("playlist_name"), rs.getTimestamp("created_at"), -1, rs.getInt("song_count"),
+							rs.getString("member_nickname"), rs.getInt("first_album_id")));
 				}
 			}
 		} catch (SQLException e) {
@@ -63,21 +62,21 @@ public class PlaylistMainDao {
 	}
 
 	private List<PlaylistPreviewDto> findPlaylistsPopularByLimit(int limit, Connection conn) {
-		String sql = "SELECT * " + "FROM ( " + "    SELECT inner_.*, ROWNUM rn " + "    FROM ( " + "        SELECT "
-				+ "            p.id AS playlist_id, " + "            m.id AS member_id, "
-				+ "            p.name AS playlist_name, " + "            p.created_at AS created_at, "
-				+ "            sc.song_count, " + "            lc.like_count, "
-				+ "            m.nickname AS member_nickname, " + "            s.album_id AS first_album_id "
-				+ "        FROM playlists p " + "        LEFT JOIN members m ON p.member_id = m.id "
-				+ "        LEFT JOIN ( " + "            SELECT playlist_id, COUNT(*) AS song_count "
-				+ "            FROM playlist_songs " + "            GROUP BY playlist_id "
-				+ "        ) sc ON p.id = sc.playlist_id " + "        LEFT JOIN ( "
-				+ "            SELECT playlist_id, COUNT(DISTINCT member_id) AS like_count " + "            FROM likes "
-				+ "            GROUP BY playlist_id " + "        ) lc ON p.id = lc.playlist_id "
-				+ "        LEFT JOIN ( " + "            SELECT playlist_id, song_id "
-				+ "            FROM playlist_songs " + "            WHERE turn = 1 "
-				+ "        ) ps2 ON p.id = ps2.playlist_id " + "        LEFT JOIN songs s ON ps2.song_id = s.id "
-				+ "        ORDER BY lc.like_count DESC NULLS LAST " + "    ) inner_ " + "    WHERE ROWNUM <= ? " + ")";
+		String sql = "SELECT *  " + "FROM (  " + "    SELECT inner_.*, ROWNUM rn  " + "    FROM (  "
+				+ "        SELECT  " + "            p.id AS playlist_id,  " + "            m.id AS member_id,  "
+				+ "            p.name AS playlist_name,  " + "            p.created_at AS created_at,  "
+				+ "            sc.song_count,  " + "            NVL(plc.like_count, 0) AS like_count,  "
+				+ "            m.nickname AS member_nickname,  " + "            s.album_id AS first_album_id  "
+				+ "        FROM playlists p  " + "        LEFT JOIN members m ON p.member_id = m.id  "
+				+ "        LEFT JOIN (  " + "            SELECT playlist_id, COUNT(*) AS song_count  "
+				+ "            FROM playlist_songs  " + "            GROUP BY playlist_id  "
+				+ "        ) sc ON p.id = sc.playlist_id  "
+				+ "        LEFT JOIN playlist_like_count plc ON p.id = plc.playlist_id  " + "        LEFT JOIN (  "
+				+ "            SELECT playlist_id, song_id  " + "            FROM playlist_songs  "
+				+ "            WHERE turn = 1  " + "        ) ps2 ON p.id = ps2.playlist_id  "
+				+ "        LEFT JOIN songs s ON ps2.song_id = s.id  "
+				+ "        ORDER BY NVL(plc.like_count, 0) DESC NULLS LAST  " + "    ) inner_  "
+				+ "    WHERE ROWNUM <= ?  " + ")";
 
 		List<PlaylistPreviewDto> playlistPreviewDtos = new ArrayList<PlaylistPreviewDto>();
 

--- a/semi2/src/main/java/com/plick/search/SearchDao.java
+++ b/semi2/src/main/java/com/plick/search/SearchDao.java
@@ -16,11 +16,12 @@ public class SearchDao {
 	public ArrayList<SearchAlbumDto> searchAlbums(String search, int currentPage, int pageSize) {
 		try {
 			conn = com.plick.db.DBConnector.getConn();
-			int start = (currentPage-1)*pageSize+1;
-			int end = currentPage*pageSize;
+			int start = (currentPage - 1) * pageSize + 1;
+			int end = currentPage * pageSize;
 			String sql = "select *  " + "from (select rownum rn, alb.*,members.nickname "
 					+ "    from (select * from albums where lower(name) like lower(?) order by released_at desc) alb "
-					+ "        left join members " + "        on alb.member_id = members.id ) " + "where rn >=? and rn <=?";
+					+ "        left join members " + "        on alb.member_id = members.id ) "
+					+ "where rn >=? and rn <=?";
 			ps = conn.prepareStatement(sql);
 			ps.setString(1, "%" + search + "%");
 			ps.setInt(2, start);
@@ -63,13 +64,14 @@ public class SearchDao {
 	}
 
 	// 아티스트 검색
-	public ArrayList<SearchArtistDto> searchAritists(String search, int currentPage,int pageSize) {
+	public ArrayList<SearchArtistDto> searchAritists(String search, int currentPage, int pageSize) {
 		try {
 			conn = com.plick.db.DBConnector.getConn();
-			int start = (currentPage-1)*pageSize+1;
-			int end = currentPage*pageSize;
+			int start = (currentPage - 1) * pageSize + 1;
+			int end = currentPage * pageSize;
 			String sql = "select * from (select rownum rn, mem.id member_id, mem.name, mem.nickname memnickname, mem.email, mem.access_type  "
-					+ "    from (select * from members where lower(members.nickname) like lower(?)) mem) " + "where rn >=? and rn <=?";
+					+ "    from (select * from members where lower(members.nickname) like lower(?)) mem) "
+					+ "where rn >=? and rn <=?";
 			ps = conn.prepareStatement(sql);
 			ps.setString(1, "%" + search + "%");
 			ps.setInt(2, start);
@@ -107,17 +109,18 @@ public class SearchDao {
 	}
 
 	// 노래 검색 최신순
-	public ArrayList<SearchSongDto> searchSongs(String search, int currentPage,int pageSize) {
+	public ArrayList<SearchSongDto> searchSongs(String search, int currentPage, int pageSize) {
 		try {
 			conn = com.plick.db.DBConnector.getConn();
-			int start = (currentPage-1)*pageSize+1;
-			int end = currentPage*pageSize;
+			int start = (currentPage - 1) * pageSize + 1;
+			int end = currentPage * pageSize;
 			String sql = "select * from (select rownum rn, so.* "
 					+ "    from (select songs.id song_id,songs.name song_name,albums.id album_id,albums.created_at, "
 					+ "            albums.name album_name,albums.member_id,members.nickname "
 					+ "        from songs,albums,members  "
 					+ "        where songs.album_id = albums.id and members.id=albums.member_id  "
-					+ "        and lower(songs.name) like lower(?) " + "        order by created_at desc) so) where rn >=? and rn <=?";
+					+ "        and lower(songs.name) like lower(?) "
+					+ "        order by created_at desc) so) where rn >=? and rn <=?";
 			ps = conn.prepareStatement(sql);
 			ps.setString(1, "%" + search + "%");
 			ps.setInt(2, start);
@@ -158,24 +161,24 @@ public class SearchDao {
 	}
 
 	// 플리 검색 최신순
-	public ArrayList<SearchPlaylistDto> searchPlaylists(String search, int currentPage,int pageSize) {
+	public ArrayList<SearchPlaylistDto> searchPlaylists(String search, int currentPage, int pageSize) {
 		try {
 			conn = com.plick.db.DBConnector.getConn();
-			int start = (currentPage-1)*pageSize+1;
-			int end = currentPage*pageSize;
-			String sql = "SELECT * FROM (SELECT rownum rn,pl.* FROM (SELECT p.id AS playlist_id, "
-					+ "					m.id AS member_id,p.name AS playlist_name,  "
-					+ "					p.created_at AS created_at,COUNT(DISTINCT ps.song_id) AS song_count,  "
-					+ "					COUNT(DISTINCT l.member_id) AS like_count,m.nickname AS member_nickname,  "
-					+ "					s.album_id AS first_album_id FROM playlists p  "
-					+ "					LEFT JOIN playlist_songs ps ON p.id = ps.playlist_id "
-					+ "					LEFT JOIN likes l ON p.id = l.playlist_id  "
-					+ "					LEFT JOIN members m ON p.member_id = m.id  "
-					+ "					LEFT JOIN playlist_songs ps2 ON p.id = ps2.playlist_id AND ps2.turn = 1  "
-					+ "					LEFT JOIN songs s ON ps2.song_id = s.id GROUP BY  "
-					+ "					 p.id, p.name, p.created_at, m.id, m.nickname, s.album_id "
-					+ "					ORDER BY created_at DESC) pl)  "
-					+ "WHERE lower(playlist_name) LIKE lower(?) AND rn >=? and rn <=?";
+			int start = (currentPage - 1) * pageSize + 1;
+			int end = currentPage * pageSize;
+			String sql = "SELECT * FROM (" + "    SELECT rownum rn, pl.* FROM (" + "        SELECT "
+					+ "            p.id AS playlist_id, " + "            m.id AS member_id, "
+					+ "            p.name AS playlist_name, " + "            p.created_at AS created_at, "
+					+ "            COUNT(DISTINCT ps.song_id) AS song_count, "
+					+ "            NVL(plc.like_count, 0) AS like_count, "
+					+ "            m.nickname AS member_nickname, " + "            s.album_id AS first_album_id "
+					+ "        FROM playlists p " + "        LEFT JOIN playlist_songs ps ON p.id = ps.playlist_id "
+					+ "        LEFT JOIN playlist_like_count plc ON p.id = plc.playlist_id "
+					+ "        LEFT JOIN members m ON p.member_id = m.id "
+					+ "        LEFT JOIN playlist_songs ps2 ON p.id = ps2.playlist_id AND ps2.turn = 1 "
+					+ "        LEFT JOIN songs s ON ps2.song_id = s.id " + "        WHERE LOWER(p.name) LIKE LOWER(?) " // 여기!
+					+ "        GROUP BY p.id, p.name, p.created_at, m.id, m.nickname, plc.like_count, s.album_id "
+					+ "        ORDER BY p.created_at DESC " + "    ) pl " + ") " + "WHERE rn >= ? AND rn <= ?";
 			ps = conn.prepareStatement(sql);
 			ps.setString(1, "%" + search + "%");
 			ps.setInt(2, start);
@@ -187,12 +190,14 @@ public class SearchDao {
 				int memberId = rs.getInt("member_id");
 				String playlistName = rs.getString("playlist_name");
 				Timestamp createdAt = rs.getTimestamp("created_at");
-				int songCount= rs.getInt("song_count");
-				int likeCount= rs.getInt("like_count");
-				String nickname = rs.getString("member_nickname");;
-				int firstAlbumId= rs.getInt("first_album_id");
-			
-				SearchPlaylistDto dto = new SearchPlaylistDto(playlistId, memberId, playlistName, createdAt, songCount, likeCount, nickname, firstAlbumId);
+				int songCount = rs.getInt("song_count");
+				int likeCount = rs.getInt("like_count");
+				String nickname = rs.getString("member_nickname");
+				;
+				int firstAlbumId = rs.getInt("first_album_id");
+
+				SearchPlaylistDto dto = new SearchPlaylistDto(playlistId, memberId, playlistName, createdAt, songCount,
+						likeCount, nickname, firstAlbumId);
 				arr.add(dto);
 			}
 			return arr;
@@ -214,93 +219,105 @@ public class SearchDao {
 		}
 
 	}
+
 	// 무드 검색 인기순
-		public ArrayList<SearchMoodDto> searchMood(String search, int currentPage,int pageSize) {
-			try {
-				conn = com.plick.db.DBConnector.getConn();
-				int start = (currentPage-1)*pageSize+1;
-				int end = currentPage*pageSize;
-				String sql = "SELECT * FROM (SELECT rownum rn, pl.* FROM (SELECT p.id AS playlist_id,p.mood1,p.mood2, "
-						+ "					m.id AS member_id,p.name AS playlist_name,  "
-						+ "					p.created_at AS created_at,COUNT(DISTINCT ps.song_id) AS song_count,  "
-						+ "					COUNT(DISTINCT l.member_id) AS like_count,m.nickname AS member_nickname,  "
-						+ "					s.album_id AS first_album_id FROM playlists p  "
-						+ "					LEFT JOIN playlist_songs ps ON p.id = ps.playlist_id  "
-						+ "					LEFT JOIN likes l ON p.id = l.playlist_id  "
-						+ "					LEFT JOIN members m ON p.member_id = m.id  "
-						+ "					LEFT JOIN playlist_songs ps2 ON p.id = ps2.playlist_id AND ps2.turn = 1  "
-						+ "					LEFT JOIN songs s ON ps2.song_id = s.id GROUP BY  "
-						+ "					 p.id, p.name, p.created_at,p.mood1,p.mood2, m.id, m.nickname, s.album_id  "
-						+ "					ORDER BY like_count DESC) pl) "
-						+ "WHERE rn >=? and rn <=? AND mood1 LIKE ? or mood2 LIKE ? ";
-				ps = conn.prepareStatement(sql);
-				ps.setInt(1, start);
-				ps.setInt(2, end);
-				ps.setString(3, "%" + search + "%");
-				ps.setString(4, "%" + search + "%");
-				rs = ps.executeQuery();
-				ArrayList<SearchMoodDto> arr = new ArrayList<SearchMoodDto>();
-				while (rs.next()) {
-					int playlistId = rs.getInt("playlist_id");
-					String mood1 = rs.getString("mood1");
-					String mood2 = rs.getString("mood2");
-					int memberId = rs.getInt("member_id");
-					String playlistName = rs.getString("playlist_name");
-					Timestamp createdAt = rs.getTimestamp("created_at");
-					int songCount= rs.getInt("song_count");
-					int likeCount= rs.getInt("like_count");
-					String nickname = rs.getString("member_nickname");;
-					int firstAlbumId= rs.getInt("first_album_id");
-				
-					SearchMoodDto dto = new SearchMoodDto(playlistId, mood1, mood2, memberId, playlistName, createdAt, songCount, likeCount, nickname, firstAlbumId);
-					arr.add(dto);
-				}
-				return arr;
-			} catch (SQLException e) {
-				e.printStackTrace();
-				return null;
+	public ArrayList<SearchMoodDto> searchMood(String search, int currentPage, int pageSize) {
+		try {
+			conn = com.plick.db.DBConnector.getConn();
+			int start = (currentPage - 1) * pageSize + 1;
+			int end = currentPage * pageSize;
+			String sql = "SELECT * FROM (" + "    SELECT rownum rn, pl.* FROM (" + "        SELECT "
+					+ "            p.id AS playlist_id, " + "            p.mood1, " + "            p.mood2, "
+					+ "            m.id AS member_id, " + "            p.name AS playlist_name, "
+					+ "            p.created_at AS created_at, "
+					+ "            COUNT(DISTINCT ps.song_id) AS song_count, "
+					+ "            NVL(plc.like_count, 0) AS like_count, "
+					+ "            m.nickname AS member_nickname, " + "            s.album_id AS first_album_id "
+					+ "        FROM playlists p " + "        LEFT JOIN playlist_songs ps ON p.id = ps.playlist_id "
+					+ "        LEFT JOIN playlist_like_count plc ON p.id = plc.playlist_id "
+					+ "        LEFT JOIN members m ON p.member_id = m.id "
+					+ "        LEFT JOIN playlist_songs ps2 ON p.id = ps2.playlist_id AND ps2.turn = 1 "
+					+ "        LEFT JOIN songs s ON ps2.song_id = s.id "
+					+ "        GROUP BY p.id, p.name, p.created_at, p.mood1, p.mood2, m.id, m.nickname, plc.like_count, s.album_id "
+					+ "        ORDER BY like_count DESC " + "    ) pl " + ") "
+					+ "WHERE rn >= ? AND rn <= ? AND (mood1 LIKE ? OR mood2 LIKE ?)";
+			ps = conn.prepareStatement(sql);
+			ps.setInt(1, start);
+			ps.setInt(2, end);
+			ps.setString(3, "%" + search + "%");
+			ps.setString(4, "%" + search + "%");
+			rs = ps.executeQuery();
+			ArrayList<SearchMoodDto> arr = new ArrayList<SearchMoodDto>();
+			while (rs.next()) {
+				int playlistId = rs.getInt("playlist_id");
+				String mood1 = rs.getString("mood1");
+				String mood2 = rs.getString("mood2");
+				int memberId = rs.getInt("member_id");
+				String playlistName = rs.getString("playlist_name");
+				Timestamp createdAt = rs.getTimestamp("created_at");
+				int songCount = rs.getInt("song_count");
+				int likeCount = rs.getInt("like_count");
+				String nickname = rs.getString("member_nickname");
+				;
+				int firstAlbumId = rs.getInt("first_album_id");
 
-			} finally {
-				try {
-					if (rs != null)
-						rs.close();
-					if (ps != null)
-						ps.close();
-					if (conn != null)
-						conn.close();
-				} catch (Exception e2) {
-					e2.printStackTrace();
-				}
+				SearchMoodDto dto = new SearchMoodDto(playlistId, mood1, mood2, memberId, playlistName, createdAt,
+						songCount, likeCount, nickname, firstAlbumId);
+				arr.add(dto);
 			}
+			return arr;
+		} catch (SQLException e) {
+			e.printStackTrace();
+			return null;
 
-		}
-		//앨범 검색 전체 데이터 수
-		// "select count(*) from albums where name like ?"
-		//노래 검색 전체 데이터 수
-		//select count(*) from songs where name like '%스%'
-		//플리 검색 전체 데이터 수
-		//select count(*) from playlists where name like '%스%'
-		//아티스트 검색 전체 데이터 수
-		//select count(*) from members where nickname like '%스%'
-		public int showTotalResults(String table,String column,String search) {
+		} finally {
 			try {
-				conn = com.plick.db.DBConnector.getConn();
-				String sql =  "select count(*) from "+table+" where lower("+column+") like lower(?)";
-				ps = conn.prepareStatement(sql);
-				ps.setString(1, "%"+search+"%");
-				rs = ps.executeQuery();
-				if(!rs.next()) return -1;
-				return rs.getInt(1);
-			} catch (SQLException e) {
-				e.printStackTrace();
+				if (rs != null)
+					rs.close();
+				if (ps != null)
+					ps.close();
+				if (conn != null)
+					conn.close();
+			} catch (Exception e2) {
+				e2.printStackTrace();
+			}
+		}
+
+	}
+
+	// 앨범 검색 전체 데이터 수
+	// "select count(*) from albums where name like ?"
+	// 노래 검색 전체 데이터 수
+	// select count(*) from songs where name like '%스%'
+	// 플리 검색 전체 데이터 수
+	// select count(*) from playlists where name like '%스%'
+	// 아티스트 검색 전체 데이터 수
+	// select count(*) from members where nickname like '%스%'
+	public int showTotalResults(String table, String column, String search) {
+		try {
+			conn = com.plick.db.DBConnector.getConn();
+			String sql = "select count(*) from " + table + " where lower(" + column + ") like lower(?)";
+			ps = conn.prepareStatement(sql);
+			ps.setString(1, "%" + search + "%");
+			rs = ps.executeQuery();
+			if (!rs.next())
 				return -1;
-			}finally {
-				try {
-					if(rs!=null)rs.close();
-					if(ps!=null)ps.close();
-					if(conn!=null)conn.close();
-				}catch(Exception e2) {e2.printStackTrace();}
+			return rs.getInt(1);
+		} catch (SQLException e) {
+			e.printStackTrace();
+			return -1;
+		} finally {
+			try {
+				if (rs != null)
+					rs.close();
+				if (ps != null)
+					ps.close();
+				if (conn != null)
+					conn.close();
+			} catch (Exception e2) {
+				e2.printStackTrace();
 			}
 		}
+	}
 
 }


### PR DESCRIPTION
여태까지 플레이리스트 좋아요가 하나의 컬럼임.
그래서 페이지를 불러올때마다 수많은 좋아요 컬럼들을 조인하고 rownum으로 불러오는데, 그렇게 하면 1분 이상이 소요됨.
테이블 하나를 추가해서 플레이리스트마다 총 좋아요를 저장할 것임.
플레이리스트 좋아요 수를 불러오는 dao와 페이지들을 수정할 것임.

1. 플레이리스트 좋아요 수가 필요한 페이지들이 사용하는 dao를 전부 playlist_like_count 테이블을 사용하게 변경함.
2. 플레이리스트 검색 페이지에서 플레이리스트가 검색되지 않는 문제 수정.
* 원인 : dao에서 rownum을 먼저 부여하고, 그 뒤에 like로 검색하고 있었음. 
* 쿼리 수정으로 수정완료