### PR TITLE
Fix/playlist/details/comments 404 profile image and fix 

### DIFF
--- a/semi2/src/main/webapp/artist/main.jsp
+++ b/semi2/src/main/webapp/artist/main.jsp
@@ -262,7 +262,7 @@ boolean isArtist = "artist".equals(artistDto.getAccessType());
 				<div class="gallery-card-artist-name-myplaylist">
 					<div>
 						<img src="/semi2/resources/images/design/likes-icon.png"
-							width="15">&nbsp;<%=playlistPreview.getLikeCount()%>
+							width="15">&nbsp;<%=playlistPreview.getLikeCount()>=1000?playlistPreview.getLikeCount()/1000+"K":playlistPreview.getLikeCount()%>
 						|
 						<%=playlistPreview.getSongCount()%>곡 |
 						<%=playlistPreview.getCreatedAt().toString().substring(0, 10)%>

--- a/semi2/src/main/webapp/playlist/details.jsp
+++ b/semi2/src/main/webapp/playlist/details.jsp
@@ -530,6 +530,7 @@ boolean isLiked = playlistDetailDto.getIsLiked();
 							<td
 								class="comment-profile<%=playlistComment.getParentId() > 0 ? "-answer" : ""%>"><img
 								src="/semi2/resources/images/member/<%=playlistComment.getMemberId()%>/profile.jpg"
+								onerror="this.src='/semi2/resources/images/member/default-profile.jpg';"
 								class="comment-profile-image" />
 								<div class="comment-profile-nickname"><%=playlistComment.getNickname()%></div>
 							</td>


### PR DESCRIPTION
1. 플레이리스트 디테일 페이지 댓글에서 사용자 프로필 이미지 디폴트값이 없어서 404 뜨는 문제 수정
* 온에러 디폴트이미지 추가

2. 아티스트 메인 좋아요 카운팅이 길어져서 줄바꿈 되는 문제 수정 
* 좋아요 서식 변경 123456 -> 123K