### PR TITLE
Fix/selt registering album check sequence number first

### DIFF
--- a/semi2/src/main/java/com/plick/album/AlbumDao.java
+++ b/semi2/src/main/java/com/plick/album/AlbumDao.java
@@ -15,15 +15,16 @@ public class AlbumDao {
 	public int addAlbum(AlbumDto dto) {
 		try {
 			conn = com.plick.db.DBConnector.getConn();
-			String sql = "INSERT INTO albums VALUES (seq_albums_id.nextval, ?, ?, ?, ?, ?, ?, ?, systimestamp)";
+			String sql = "INSERT INTO albums VALUES (?, ?, ?, ?, ?, ?, ?, ?, systimestamp)";
 			pstmt = conn.prepareStatement(sql);
-			pstmt.setInt(1, dto.getMemberId());
-			pstmt.setString(2, dto.getName());
-			pstmt.setString(3, dto.getDescription());
-			pstmt.setString(4, dto.getGenre1());
-			pstmt.setString(5, dto.getGenre2());
-			pstmt.setString(6, dto.getGenre3());
-			pstmt.setTimestamp(7, dto.getReleasedAt());
+			pstmt.setInt(1, dto.getId());
+			pstmt.setInt(2, dto.getMemberId());
+			pstmt.setString(3, dto.getName());
+			pstmt.setString(4, dto.getDescription());
+			pstmt.setString(5, dto.getGenre1());
+			pstmt.setString(6, dto.getGenre2());
+			pstmt.setString(7, dto.getGenre3());
+			pstmt.setTimestamp(8, dto.getReleasedAt());
 			int result = pstmt.executeUpdate();
 			return result;
 		}catch(Exception e) {
@@ -142,7 +143,7 @@ public class AlbumDao {
 	public int findMaxAlbumId() {
 		try {
 			conn = com.plick.db.DBConnector.getConn();
-			String sql = "SELECT MAX(id) as maxid FROM albums";
+			String sql = "SELECT seq_albums_id.NEXTVAL as maxid FROM dual";
 			pstmt = conn.prepareStatement(sql);
 			rs = pstmt.executeQuery();
 			if (rs.next()) {

--- a/semi2/src/main/java/com/plick/album/AlbumDao.java
+++ b/semi2/src/main/java/com/plick/album/AlbumDao.java
@@ -211,4 +211,30 @@ public class AlbumDao {
 			}
 		}
 	}
+	public int checkAlbumDuplicate(int albumId) {
+		try {
+			conn = com.plick.db.DBConnector.getConn();
+			String sql = "SELECT id FROM albums WHERE id = ?";
+			pstmt = conn.prepareStatement(sql);
+			pstmt.setInt(1, albumId);
+			rs = pstmt.executeQuery();
+			if (rs.next()) {
+				return 1;
+			}else {
+				return 0;
+			}
+			
+		}catch(Exception e){
+			e.printStackTrace();
+			return ERROR;
+		}finally {
+			try {
+				if(rs!=null)rs.close();
+				if(pstmt!=null)pstmt.close();
+				if(conn!=null)conn.close();
+			}catch(Exception e2) {
+				e2.printStackTrace();
+			}
+		}
+	}
 }

--- a/semi2/src/main/webapp/member/find/password-reset.jsp
+++ b/semi2/src/main/webapp/member/find/password-reset.jsp
@@ -56,8 +56,8 @@ function formCheck(event) {
 		<div class="blank"></div>
 		<div class="signup-title">비밀번호 찾기</div>
 		<div class="blank3"></div>
-		<input type="password" id = "pwd" name = "password" class="login-text" placeholder="새 비밀번호" onchange = "testPassword()">
-		<input type="password" id = "pwdTest" class="login-text" placeholder="새 비밀번호 확인" onchange = "testPassword()">
+		<input type="password" id = "pwd" name = "password" class="login-text" placeholder="새 비밀번호" oninput = "testPassword()">
+		<input type="password" id = "pwdTest" class="login-text" placeholder="새 비밀번호 확인" oninput = "testPassword()">
 		<div>
 		<label id = pwdCheck></label>
 		</div class="signin-hidden">

--- a/semi2/src/main/webapp/member/signup/form.jsp
+++ b/semi2/src/main/webapp/member/signup/form.jsp
@@ -31,8 +31,8 @@ emailForms.add("daum.net");
 		<div class="signup-text-name">성함 : <%=request.getParameter("name") %> 님</div>
 		<div class="signup-text-name">전화번호 : <%=request.getParameter("tel") %></div>
 		<input type="text" maxlength="10" id = "emailHead" placeholder="이메일" class="signup-text-email">@
-		<input type="text" maxlength="15" id = "emailTail" value = "선택" readonly onchange="assembleEmailF();" class="signup-text-email">
-		<select class="signup-select" onchange="changeDirectInput(this);">
+		<input type="text" maxlength="15" id = "emailTail" value = "선택" readonly oninput="assembleEmailF();" class="signup-text-email">
+		<select class="signup-select" oninput="changeDirectInput(this);">
 		<option disabled selected>선택</option>
 <%
 for (int i = 0; i < emailForms.size(); i++) {
@@ -48,16 +48,16 @@ for (int i = 0; i < emailForms.size(); i++) {
 		</div>
 		<input type = "text" id = "assembleEmail" name = "email" style = "display: none;"> 
 		<div>
-		<input type="text" maxlength = "15" id = "nickname" name = "nickname" class="signup-text"placeholder="닉네임" onchange = "testNickname();">
+		<input type="text" maxlength = "15" id = "nickname" name = "nickname" class="signup-text"placeholder="닉네임" oninput = "testNickname();">
 		</div>
 		<div class="signin-hidden">
 		<label id = "checkNicknameDuplicate"></label>
 		</div>
 		<div>
-		<input type="password" maxlength = "12" id = "pwd" name = "password" class="signup-text" placeholder="비밀번호" onchange="testPassword();">
+		<input type="password" maxlength = "12" id = "pwd" name = "password" class="signup-text" placeholder="비밀번호" oninput="testPassword();">
 		</div>
 		<div>
-		<input type="password" maxlength = "12" id = "pwdTest" class="signup-text" placeholder="비밀번호 확인" onchange="testPassword();">
+		<input type="password" maxlength = "12" id = "pwdTest" class="signup-text" placeholder="비밀번호 확인" oninput="testPassword();">
 		</div>
 		<div class="signin-hidden">
 		<label id = "pwdCheck"></label>

--- a/semi2/src/main/webapp/mypage/album-management/album-form_ok.jsp
+++ b/semi2/src/main/webapp/mypage/album-management/album-form_ok.jsp
@@ -30,7 +30,7 @@ request.setCharacterEncoding("UTF-8");
 AlbumDao aDao = new AlbumDao();
 
 
-int albumId = request.getParameter("albumId")!=null ? Integer.parseInt(request.getParameter("albumId")) : aDao.findMaxAlbumId()+1;
+int albumId = request.getParameter("albumId")!=null ? Integer.parseInt(request.getParameter("albumId")) : aDao.findMaxAlbumId();
 
 
 String coverPath = request.getRealPath("/resources/images/album/"+albumId);
@@ -45,6 +45,7 @@ if(!f2.exists()) f2.mkdirs();
 MultipartRequest mr = new MultipartRequest(request, coverPath, 20 * 1024 * 1024, "UTF-8");
 
 AlbumDto albumDto = new AlbumDto();
+albumDto.setId(albumId);
 albumDto.setName(mr.getParameter("name"));
 albumDto.setMemberId(signedinDto.getMemberId());
 albumDto.setDescription(mr.getParameter("description"));
@@ -87,7 +88,6 @@ if (mr.getFilesystemName("inputAlbumCover")!=null){
 		
 	}
 }
-session.setAttribute("albumId", null);
 
 %>
 <script>

--- a/semi2/src/main/webapp/mypage/album-management/album-form_ok.jsp
+++ b/semi2/src/main/webapp/mypage/album-management/album-form_ok.jsp
@@ -32,6 +32,8 @@ AlbumDao aDao = new AlbumDao();
 
 int albumId = request.getParameter("albumId")!=null ? Integer.parseInt(request.getParameter("albumId")) : aDao.findMaxAlbumId();
 
+if(aDao.checkAlbumDuplicate(albumId) != 0){
+
 
 String coverPath = request.getRealPath("/resources/images/album/"+albumId);
 String songsPath = request.getRealPath("/resources/songs/"+albumId);
@@ -94,4 +96,12 @@ if (mr.getFilesystemName("inputAlbumCover")!=null){
 if("<%=msg %>"!="") window.alert("<%=msg %>");
 parent.location.href = "/semi2/mypage/album-management/song.jsp?albumId=<%=albumId%>";
 </script>
-
+<%}else{
+%>
+<script>
+window.alert("현재 작업 중인 아티스트가 너무 많습니다. 다시 시도 해주세요.");
+parent.location.href = "/semi2/mypage/album-management/main.jsp";
+</script>
+<%
+}
+%>

--- a/semi2/src/main/webapp/mypage/album-management/song-form_ok.jsp
+++ b/semi2/src/main/webapp/mypage/album-management/song-form_ok.jsp
@@ -28,7 +28,7 @@
 <%
 SignedinDto signedinDto = (SignedinDto) session.getAttribute("signedinDto");
 request.setCharacterEncoding("UTF-8");
-String albumIdInSession = session.getAttribute("albumId") != null ? session.getAttribute("albumId").toString() : null;
+String albumIdInSession = request.getParameter("albumId") != null ? request.getParameter("albumId") : null;
 if(albumIdInSession != null){
 
 String path = request.getRealPath("/resources/songs/"+albumIdInSession);
@@ -39,7 +39,7 @@ if(!f.exists()) f.mkdirs();
 MultipartRequest mr = new MultipartRequest(request, path, 20 * 1024 * 1024, "UTF-8");
 
 SongsDto songDto = new SongsDto();
-songDto.setAlbum_id(Integer.parseInt(session.getAttribute("albumId").toString()));
+songDto.setAlbum_id(Integer.parseInt(request.getParameter("albumId")));
 songDto.setName(mr.getParameter("name"));
 songDto.setComposer(mr.getParameter("composer"));
 songDto.setLyricist(mr.getParameter("lyricist"));

--- a/semi2/src/main/webapp/mypage/album-management/song.jsp
+++ b/semi2/src/main/webapp/mypage/album-management/song.jsp
@@ -25,9 +25,7 @@ if (session.getAttribute("signedinDto") == null) {
 	<%@ include file="/header.jsp"%>
 	<%@ include file="/mypage/mypage-header.jsp"%>
 	<%
-	if (request.getParameter("albumId") != null){
-		session.setAttribute("albumId", request.getParameter("albumId"));
-
+if(request.getParameter("albumId")!=null){
 	int albumId = (Integer.parseInt(request.getParameter("albumId")));
 
 	AlbumDto aDto = mdao.findInfoAlbums(albumId);

--- a/semi2/src/main/webapp/mypage/password-reset.jsp
+++ b/semi2/src/main/webapp/mypage/password-reset.jsp
@@ -71,9 +71,9 @@ function formCheck(event) {
 			<h2>비밀번호 찾기</h2>
 		</div>
 	<form action = "password-reset_ok.jsp" method = "post" onsubmit = "formCheck(event)">
-		<input type="password" id = "pwd" name = "password" placeholder="새 비밀번호" onchange = "testPassword()" class="login-text">
+		<input type="password" id = "pwd" name = "password" placeholder="새 비밀번호" oninput = "testPassword()" class="login-text">
 		<br>
-		<input type="password" id = "pwdTest" placeholder="새 비밀번호 확인" onchange = "testPassword()" class="login-text">
+		<input type="password" id = "pwdTest" placeholder="새 비밀번호 확인" oninput = "testPassword()" class="login-text">
 		<div class="signin-hidden">
 		<label id = pwdCheck></label>
 		</div>

--- a/semi2/src/main/webapp/mypage/password-reset_ok.jsp
+++ b/semi2/src/main/webapp/mypage/password-reset_ok.jsp
@@ -6,8 +6,10 @@
 request.setCharacterEncoding("UTF-8");
 SignedinDto signedinDto = (SignedinDto) session.getAttribute("signedinDto");
 MemberDao memberDao = new MemberDao();
+if (request.getParameter("password")!=null){
 int result = memberDao.resetPassword(request.getParameter("password"), signedinDto.getMemberEmail());
 if (result > 0){
+	signedinDto.setMemberPassword(request.getParameter("password"));
 %>
 <script>
 window.alert("비밀번호 변경성공");
@@ -21,5 +23,13 @@ window.alert("비밀번호 변경실패");
 history.back();
 </script>
 <%
+}
+}else{
+	%>
+	<script>
+	window.alert("잘못된 접근입니다. 메인페이지로 돌아갑니다.");
+	location.href = "/semi2/main.jsp";
+	</script>
+	<%	
 }
 %>

--- a/semi2/src/main/webapp/mypage/profile.jsp
+++ b/semi2/src/main/webapp/mypage/profile.jsp
@@ -48,7 +48,7 @@ textarea::-webkit-scrollbar {
 		<div class="profile-change-card-input">
 			<input type="text" id="nickname" name="nickname"
 				value="<%=signedinDto.getMemberNickname()%>" readonly
-				onchange="checkDuplicateNickname();" class="mypage-text"> 
+				oninput="checkDuplicateNickname();" class="mypage-text"> 
 				<input type="button" id="nicknameEditButton" value="닉네임 변경"
 				onclick="changeNickname();" class="bt"> <label
 				id="duplicateNickname"></label> <input type="hidden"


### PR DESCRIPTION
1. 앨범 등록 시 db 등록 전에 앨범 id가 필요한데 더미 데이터 때문에 오류 발생
- 시퀀스 넘버의 naxtval을 먼저 조회하고 해당 번호로 id를 세팅해서 등록하도록 했음 

2. 사용자 경험을 위해 form에 해당하는 페이지에서 제약 사항이 실시간으로 표시되도록 onchange 이벤트를 oninput으로 변경

3. 마이 페이지에서 비밀번호 변경시 세션에 적용 되도록 변경

4. 앨범 등록시 최소한의 중복검사 추가 (동시 등록 테스트 필요)