### PR TITLE
fix: fix no playlist_like_count table when add new playlist

### DIFF
--- a/semi2/src/main/webapp/playlist/mylist/add_ok.jsp
+++ b/semi2/src/main/webapp/playlist/mylist/add_ok.jsp
@@ -31,7 +31,7 @@ playlistName = "default name";
 }
 
 PlaylistMylistDao playlistMylistDao = new PlaylistMylistDao();
-if (!playlistMylistDao.addPlaylistByMemberId(loggedinUserId, playlistName)) {
+if (!playlistMylistDao.addPlaylistWithLikeCount(loggedinUserId, playlistName)) {
 %>
 <script>
 	showAlertAndGoBack('오류가 발생했습니다');


### PR DESCRIPTION
1. 새 플레이리스트를 추가할 때 playlist_like_count 테이블이 생성되지 않아서 새 플레이리스트 좋아요 수가 집계 안되는 문제 수정
* 해결: 플레이리스트 추가할 때 playlist_like_count 테이블에도 추가하게 변경