### PR TITLE
fix: fix add-playlist feature on modal

### DIFF
--- a/semi2/src/main/webapp/playlist/mylist/popup-list-form_ok.jsp
+++ b/semi2/src/main/webapp/playlist/mylist/popup-list-form_ok.jsp
@@ -36,7 +36,7 @@ playlistName = "default name";
 }
 
 PlaylistMylistDao playlistMylistDao = new PlaylistMylistDao();
-if (!playlistMylistDao.addPlaylistByMemberId(loggedinUserId, playlistName)) {
+if (!playlistMylistDao.addPlaylistWithLikeCount(loggedinUserId, playlistName)){
 %>
 <script>
 	showAlertAndGoBack('오류가 발생했습니다');


### PR DESCRIPTION
1. 모달창에서 add playlist 했을때 오류나는 것 수정
*원인 : 다른 페이지 수정할 때 dao를 수정했는데 메서드명을 바꿔주지 않음.